### PR TITLE
3.4 Flags.md: Fix final AL value in Subtraction Results Negative

### DIFF
--- a/Chapter 3 - Assembly/3.4 Flags.md
+++ b/Chapter 3 - Assembly/3.4 Flags.md
@@ -35,7 +35,7 @@ cmp RAX, 8  ; 2 - 8 = -6.
 ; ZF = 0, OF = 0, SF = 1
 ```
 <br />
-The following is an example where the result is too big to fit into a register. Here I'm using 8-bit registers so we can work with small numbers. The biggest number that can fit in a signed 8-bit register is 128. AL is loaded with 75 then 60 is added to it. The result of adding the two together should result in 135, but the maximum number that it can hold is 128. Because of this, the number wraps around and AL is going to be -115. This sets the OF because the result was too big for the register, and the SF flag is set because the result is negative. If this was an unsigned operation CF would be set.
+The following is an example where the result is too big to fit into a register. Here I'm using 8-bit registers so we can work with small numbers. The biggest number that can fit in a signed 8-bit register is 128. AL is loaded with 75 then 60 is added to it. The result of adding the two together should result in 135, but the maximum number that it can hold is 128. Because of this, the number wraps around and AL is going to be -121. This sets the OF because the result was too big for the register, and the SF flag is set because the result is negative. If this was an unsigned operation CF would be set.
 
 ```assembly
 mov AL, 75


### PR DESCRIPTION
Fix final AL value in the example "Subtraction Results Negative": 
-115 => -121

This absolutely matches with the discord group message - https://discordapp.com/channels/666440560625582091/666449084932030464/979143353046290432